### PR TITLE
Implement basic n8n API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,27 @@ Ce dépôt est basé sur le template officiel de plugin Jeedom et fournit un poi
    - **URL de l'instance n8n** (ex: `https://mon.n8n.local`)
    - **Clé API** (générée dans n8n > Settings > API)
 5. Testez la connexion avec le bouton **"Tester"**
+6. Notez l'URL d'API entrante affichée. Elle sera utilisée dans vos workflows n8n pour envoyer des données vers Jeedom.
+
+### Ajouter un équipement
+
+1. Dans le plugin, cliquez sur **Ajouter** puis rafraîchissez la liste des workflows.
+2. Sélectionnez le workflow souhaité et sauvegardez.
+3. Une commande **Exécuter le workflow** est créée automatiquement. Ajoutez vos commandes d'information selon vos besoins.
+
+### Exemple d'appel depuis n8n
+
+Dans votre workflow n8n, utilisez un noeud **HTTP Request** configuré en `POST` vers l'URL affichée précédemment. Renseignez les paramètres `eqLogic_id`, `cmd_name` et `value` afin de mettre à jour une commande info de Jeedom.
+
+Exemple de corps JSON envoyé :
+
+```json
+{
+  "eqLogic_id": "12",
+  "cmd_name": "temperature",
+  "value": "23"
+}
+```
 
 ## Dépannage
 

--- a/core/api/n8n.api.php
+++ b/core/api/n8n.api.php
@@ -1,0 +1,40 @@
+<?php
+require_once __DIR__ . '/../../../../core/php/core.inc.php';
+
+header('Content-Type: application/json');
+
+$apiKey = init('apikey');
+if ($apiKey !== jeedom::getApiKey('n8nconnect')) {
+    http_response_code(401);
+    echo json_encode(['success' => false, 'error' => 'Invalid API key']);
+    exit;
+}
+
+$eqLogicId = init('eqLogic_id');
+$cmdName = init('cmd_name');
+$value = init('value');
+
+if ($eqLogicId == '' || $cmdName == '') {
+    http_response_code(400);
+    echo json_encode(['success' => false, 'error' => 'Missing parameters']);
+    exit;
+}
+
+$eqLogic = n8nconnect::byId($eqLogicId);
+if (!is_object($eqLogic)) {
+    http_response_code(404);
+    echo json_encode(['success' => false, 'error' => 'Equipment not found']);
+    exit;
+}
+
+$cmd = $eqLogic->getCmd(null, $cmdName);
+if (!is_object($cmd) || $cmd->getType() != 'info') {
+    http_response_code(404);
+    echo json_encode(['success' => false, 'error' => 'Command not found']);
+    exit;
+}
+
+$cmd->event($value);
+
+echo json_encode(['success' => true]);
+?>

--- a/core/class/n8nconnect.class.php
+++ b/core/class/n8nconnect.class.php
@@ -134,8 +134,6 @@ class n8nconnect extends eqLogic {
         // Vérifier s'il y a déjà des commandes
         $existingCmds = $this->getCmd();
         if (count($existingCmds) > 0) {
-            // Les commandes existent déjà, pas besoin de les recréer
-            $this->refreshInfo();
             return;
         }
         
@@ -149,95 +147,44 @@ class n8nconnect extends eqLogic {
             return;
         }
         
-        $commands = [
-            'run' => ['name' => __('Lancer', __FILE__), 'type' => 'action', 'subType' => 'other'],
-            'activate' => ['name' => __('Activer', __FILE__), 'type' => 'action', 'subType' => 'other'],
-            'deactivate' => ['name' => __('Désactiver', __FILE__), 'type' => 'action', 'subType' => 'other'],
-            'state' => ['name' => __('État', __FILE__), 'type' => 'info', 'subType' => 'binary']
-        ];
-        foreach ($commands as $logical => $info) {
+        $cmd = $this->getCmd(null, 'execute');
+        if (!is_object($cmd)) {
             $cmd = new n8nconnectCmd();
-            $cmd->setLogicalId($logical);
+            $cmd->setLogicalId('execute');
             $cmd->setEqLogic_id($this->getId());
-            $cmd->setType($info['type']);
-            $cmd->setSubType($info['subType']);
-            $cmd->setName($info['name']);
-            $cmd->setIsVisible(($logical !== 'state') ? 1 : 0);
-            $cmd->setIsHistorized(($logical === 'state') ? 1 : 0);
+            $cmd->setType('action');
+            $cmd->setSubType('message');
+            $cmd->setName(__('Exécuter le workflow', __FILE__));
+            $cmd->setIsVisible(1);
             $cmd->save();
         }
-        $this->refreshInfo();
     }
 
-    public function refreshInfo() {
+    public function executeWorkflow($message = '') {
         $id = $this->getConfiguration('workflow_id');
-        if (!ctype_digit((string) $id)) {
-            return;
-        }
-        try {
-            $info = self::callN8n('GET', '/workflows/' . $id);
-            $active = isset($info['active']) && $info['active'] ? 1 : 0;
-        } catch (Exception $e) {
-            $active = 0;
-            log::add('n8nconnect', 'error', 'Erreur lors de la récupération du statut : ' . $e->getMessage());
-        }
-        $cmd = $this->getCmd(null, 'state');
-        if (is_object($cmd)) {
-            $cmd->event($active);
-        }
-    }
-
-    public static function cron() {
-        foreach (self::byType('n8nconnect') as $eq) {
-            $eq->refreshInfo();
-        }
-    }
-
-    public function launch() {
-        $id = $this->getConfiguration('workflow_id');
-        if ($id == '') {
-            throw new Exception(__('ID de workflow manquant', __FILE__));
-        }
-        if (!ctype_digit((string) $id)) {
+        if ($id == '' || !ctype_digit((string) $id)) {
             throw new Exception(__('ID de workflow invalide', __FILE__));
         }
-        return self::callN8n('POST', '/workflows/' . $id . '/run');
-    }
 
-    public function activate() {
-        $id = $this->getConfiguration('workflow_id');
-        if (!ctype_digit((string) $id)) {
-            throw new Exception(__('ID de workflow invalide', __FILE__));
-        }
-        self::callN8n('POST', '/workflows/' . $id . '/activate');
-        $this->refreshInfo();
-    }
+        $payload = [
+            'source' => 'Jeedom',
+            'eqLogic_id' => $this->getId(),
+            'eqLogic_name' => $this->getName(),
+            'trigger_value' => $message,
+        ];
 
-    public function deactivate() {
-        $id = $this->getConfiguration('workflow_id');
-        if (!ctype_digit((string) $id)) {
-            throw new Exception(__('ID de workflow invalide', __FILE__));
-        }
-        self::callN8n('POST', '/workflows/' . $id . '/deactivate');
-        $this->refreshInfo();
+        self::callN8n('POST', '/workflows/' . $id . '/executions', $payload);
     }
 }
 
 class n8nconnectCmd extends cmd {
     public function execute($_options = array()) {
-        switch ($this->getLogicalId()) {
-            case 'run':
-                $this->getEqLogic()->launch();
-                return;
-            case 'activate':
-                $this->getEqLogic()->activate();
-                return;
-            case 'deactivate':
-                $this->getEqLogic()->deactivate();
-                return;
-            default:
-                throw new Exception(__('Commande inconnue', __FILE__));
+        if ($this->getLogicalId() !== 'execute') {
+            throw new Exception(__('Commande inconnue', __FILE__));
         }
+
+        $message = isset($_options['message']) ? $_options['message'] : '';
+        $this->getEqLogic()->executeWorkflow($message);
     }
 }
 

--- a/plugin_info/configuration.php
+++ b/plugin_info/configuration.php
@@ -43,6 +43,14 @@ if (!isConnect()) {
         <a class="btn btn-default" id="bt_testN8N"><i class="fas fa-check"></i> {{Tester}}</a>
       </div>
     </div>
+    <div class="form-group">
+      <label class="col-md-4 control-label">{{URL API entrante}}
+        <sup><i class="fas fa-question-circle tooltips" title="{{A utiliser dans vos workflows n8n}}"></i></sup>
+      </label>
+      <div class="col-md-8">
+        <input class="form-control" readonly value="<?php echo network::getNetworkAccess('internal', 'http') . '/core/api/jeeApi.php?plugin=n8nconnect&type=api&apikey=' . jeedom::getApiKey('n8nconnect') . '&eqLogic_id=[ID_EQUIPEMENT]&cmd_name=[NOM_COMMANDE]&value='; ?>"/>
+      </div>
+    </div>
   </fieldset>
 </form>
 <script>


### PR DESCRIPTION
## Summary
- add incoming API endpoint `core/api/n8n.api.php`
- create only one action command to execute workflows
- handle workflow execution with POST /executions
- display generated API URL in plugin configuration
- document workflow usage and incoming API

## Testing
- `npm -v`
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686d0e952c48832f8f29a2f66ab62900